### PR TITLE
PHP punctuation fix in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Using
 
 Using the Geocod.io PHP library is super simple.
 ```php
-require_once 'vendor/autoload.php'
+require_once 'vendor/autoload.php';
 use Stanley\Geocodio\Client;
 
 // Create the new Client object by passing in your api key


### PR DESCRIPTION
Added missing ";" in the end of "require_once..." line.