### PR TITLE
When reverse geocoding, we have to set the right verb

### DIFF
--- a/src/Stanley/Geocodio/Client.php
+++ b/src/Stanley/Geocodio/Client.php
@@ -77,7 +77,7 @@ class Client
     public function post($data, $fields = [], $key = null)
     {
         if ($key) $this->apiKey = $key;
-        $request = $this->bulkPost($data, $fields);
+        $request = $this->bulkPost($data, $fields, 'reverse');
         return $this->newDataObject($request->getBody());
     }
 


### PR DESCRIPTION
Otherwise all our stuff comes back as "unable to geocode"

Please merge this asap as nobody can reverse geocode without this :(