### PR TITLE
Verb is not passed to bulk post

### DIFF
--- a/src/Stanley/Geocodio/Client.php
+++ b/src/Stanley/Geocodio/Client.php
@@ -77,7 +77,7 @@ class Client
     public function post($data, $fields = [], $key = null)
     {
         if ($key) $this->apiKey = $key;
-        $request = $this->bulkPost($data, $fields);
+        $request = $this->bulkPost($data, $fields, 'reverse');
         return $this->newDataObject($request->getBody());
     }
 


### PR DESCRIPTION
This is the array I am passing.

![screen shot 2017-06-26 at 4 16 06 pm](https://user-images.githubusercontent.com/1530131/27614264-52cbd7e8-5b55-11e7-8080-26180dfa4ed5.png)

This is the code as it sits balking because it's using the wrong verb.

![screen shot 2017-06-26 at 4 16 40 pm](https://user-images.githubusercontent.com/1530131/27614274-605e8874-5b55-11e7-9771-45fad6f36d6b.png)

This is the API returning the correct data directly from PAW.

![screen shot 2017-06-26 at 4 16 55 pm](https://user-images.githubusercontent.com/1530131/27614276-627c75f8-5b55-11e7-9f12-8785e559b5d1.png)

This is the API correctly returning data after I made the change requested in this pull request. The correct "verb" is getting lost without it being specified.
![screen shot 2017-06-26 at 4 29 13 pm](https://user-images.githubusercontent.com/1530131/27614277-64b586ca-5b55-11e7-9c88-0d788403dd46.png)

Please try it for yourself. Thank you very much. Joshua Ziering