### PR TITLE
removed query string

### DIFF
--- a/src/Stanley/Geocodio/Client.php
+++ b/src/Stanley/Geocodio/Client.php
@@ -137,7 +137,6 @@ class Client
     protected function bulkPost($data, $fields, $verb = 'geocode')
     {
         $params = [
-            'q' => $data,
             'api_key' => $this->apiKey,
             'fields' => implode(',', $fields)
         ];


### PR DESCRIPTION
When bulk-geocoding records, the query string quickly exceeds the 2048 character limit for a query string and throws an exception. This essentially limits your ability to bulk-geocode to ~100 records when using this library.

Removed the "q" since it's not needed in a bulk post.