### PR TITLE
Updates to composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "stanley/geocodio-php",
     "description": "Thin wrapper for the Geocodio API",
+    "license": "MIT",
     "version": "1.3.2",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "stanley/geocodio-php",
     "description": "Thin wrapper for the Geocodio API",
     "license": "MIT",
-    "version": "1.3.2",
     "authors": [
         {
             "name": "David Stanley",


### PR DESCRIPTION
This PR makes two updates to the `composer.json` file.

First, it adds the MIT license specification. This helps Packagist determine the license. As of right now, Packagist states that there is no license information available, and this should resolve that issue.

Second, it removes the explicit version specification from the file. [Composer itself recommends omitting this option](https://getcomposer.org/doc/04-schema.md#version) when the version can be inferred through the VCS tag name. The issue is that when the version specified in the `composer.json` file does not match the version inferred from the tag name, composer treats this as a broken version, and Packagist does not serve broken versions. As an example, in this repository, the latest `1.4.0` tag has version `1.3.2` in the `composer.json` file. Because of this mismatch, composer doesn't find the `1.4.0` version, and will instead install `1.3.2` as the latest version. You can even see that the `1.4.0` tag is missing in the [Packagist list of tags](https://packagist.org/packages/stanley/geocodio-php).

Hope this helps.