### PR TITLE
Update exception namespaces

### DIFF
--- a/src/Stanley/Geocodio/Client.php
+++ b/src/Stanley/Geocodio/Client.php
@@ -3,6 +3,7 @@
 use Stanley\Geocodio\Data;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Psr7\Response;
+use Stanley\Geocodio\Exceptions;
 
 class Client
 {
@@ -119,7 +120,7 @@ class Client
             'api_key' => $this->apiKey,
             'fields' => implode(',', $fields)
         ];
-        
+
         $response = $this->client->get($verb, [
             'query' => $params
         ]);
@@ -161,15 +162,15 @@ class Client
         $reason = $response->getReasonPhrase();
         switch ($status) {
             case '403':
-                throw new Stanley\Geocodio\GeocodioAuthError($reason);
+                throw new Exceptions\GeocodioAuthError($reason);
                 break;
 
             case '422':
-                throw new Stanley\Geocodio\GeocodioDataError($reason);
+                throw new Exceptions\GeocodioDataError($reason);
                 break;
 
             case '500':
-                throw new Stanley\Geocodio\GeocodioServerError($reason);
+                throw new Exceptions\GeocodioServerError($reason);
                 break;
 
             case '200':
@@ -177,7 +178,7 @@ class Client
                 break;
 
             default:
-                throw new Stanley\Geocodio\GeocodioException("There was a problem with your request - $reason");
+                throw new Exceptions\GeocodioException("There was a problem with your request - $reason");
                 break;
         }
     }

--- a/src/Stanley/Geocodio/Exceptions/GeocodioAuthError.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioAuthError.php
@@ -1,3 +1,3 @@
 <?php namespace Stanley\Geocodio\Exceptions;
 
-class GeocodioAuthError extends Exception {}
+class GeocodioAuthError extends \Exception {}

--- a/src/Stanley/Geocodio/Exceptions/GeocodioAuthError.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioAuthError.php
@@ -1,3 +1,3 @@
-<?php namespace Stanley\Geocodio;
+<?php namespace Stanley\Geocodio\Exceptions;
 
 class GeocodioAuthError extends Exception {}

--- a/src/Stanley/Geocodio/Exceptions/GeocodioDataError.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioDataError.php
@@ -1,3 +1,3 @@
 <?php namespace Stanley\Geocodio\Exceptions;
 
-class GeocodioDataError extends Exception {}
+class GeocodioDataError extends \Exception {}

--- a/src/Stanley/Geocodio/Exceptions/GeocodioDataError.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioDataError.php
@@ -1,3 +1,3 @@
-<?php namespace Stanley\Geocodio;
+<?php namespace Stanley\Geocodio\Exceptions;
 
 class GeocodioDataError extends Exception {}

--- a/src/Stanley/Geocodio/Exceptions/GeocodioException.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioException.php
@@ -1,3 +1,3 @@
 <?php namespace Stanley\Geocodio\Exceptions;
 
-class GeocodioException extends Exception {}
+class GeocodioException extends \Exception {}

--- a/src/Stanley/Geocodio/Exceptions/GeocodioException.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioException.php
@@ -1,3 +1,3 @@
-<?php namespace Stanley\Geocodio;
+<?php namespace Stanley\Geocodio\Exceptions;
 
 class GeocodioException extends Exception {}

--- a/src/Stanley/Geocodio/Exceptions/GeocodioServerError.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioServerError.php
@@ -1,3 +1,3 @@
 <?php namespace Stanley\Geocodio\Exceptions;
 
-class GeocodioServerError extends Exception {}
+class GeocodioServerError extends \Exception {}

--- a/src/Stanley/Geocodio/Exceptions/GeocodioServerError.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioServerError.php
@@ -1,3 +1,3 @@
-<?php namespace Stanley\Geocodio;
+<?php namespace Stanley\Geocodio\Exceptions;
 
 class GeocodioServerError extends Exception {}

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use Stanley\Geocodio\Client;
+
+class ClientTest extends BaseTest
+{
+    public function testCheckResponseReturnsResponse()
+    {
+        $client = new Client('');
+
+        $mock = $this->getMock('GuzzleHttp\Psr7\Response');
+        $mock->expects($this->any())->method('getStatusCode')->will($this->returnValue('200'));
+
+        $response = $this->invokeMethod($client, 'checkResponse', [$mock]);
+
+        $this->assertEquals($mock, $response);
+    }
+
+    public function testCheckResponseThrowsAuthError()
+    {
+        $client = new Client('');
+
+        $mock = $this->getMock('GuzzleHttp\Psr7\Response');
+        $mock->expects($this->any())->method('getStatusCode')->will($this->returnValue('403'));
+        $mock->expects($this->any())->method('getReasonPhrase')->will($this->returnValue('Forbidden'));
+
+        $this->setExpectedException('Stanley\Geocodio\Exceptions\GeocodioAuthError', 'Forbidden');
+
+        $this->invokeMethod($client, 'checkResponse', [$mock]);
+    }
+
+    public function testCheckResponseThrowsDataError()
+    {
+        $client = new Client('');
+
+        $mock = $this->getMock('GuzzleHttp\Psr7\Response');
+        $mock->expects($this->any())->method('getStatusCode')->will($this->returnValue('422'));
+        $mock->expects($this->any())->method('getReasonPhrase')->will($this->returnValue('Unprocessable Entity'));
+
+        $this->setExpectedException('Stanley\Geocodio\Exceptions\GeocodioDataError', 'Unprocessable Entity');
+
+        $this->invokeMethod($client, 'checkResponse', [$mock]);
+    }
+
+    public function testCheckResponseThrowsServerError()
+    {
+        $client = new Client('');
+
+        $mock = $this->getMock('GuzzleHttp\Psr7\Response');
+        $mock->expects($this->any())->method('getStatusCode')->will($this->returnValue('500'));
+        $mock->expects($this->any())->method('getReasonPhrase')->will($this->returnValue('Internal Server Error'));
+
+        $this->setExpectedException('Stanley\Geocodio\Exceptions\GeocodioServerError', 'Internal Server Error');
+
+        $this->invokeMethod($client, 'checkResponse', [$mock]);
+    }
+
+    public function testCheckResponseThrowsUnhandledError()
+    {
+        $client = new Client('');
+
+        $mock = $this->getMock('GuzzleHttp\Psr7\Response');
+        $mock->expects($this->any())->method('getStatusCode')->will($this->returnValue('404'));
+        $mock->expects($this->any())->method('getReasonPhrase')->will($this->returnValue('Not Found'));
+
+        $this->setExpectedException('Stanley\Geocodio\Exceptions\GeocodioException', 'Not Found');
+
+        $this->invokeMethod($client, 'checkResponse', [$mock]);
+    }
+}


### PR DESCRIPTION
There are a couple issues with the custom exceptions.

First, the namespaces are not PSR4 compliant, so the exceptions will not be found by the Client. The exceptions live in the `Exceptions` subdirectory, but their namespace does not include this, so they won't be found.

Second, they all extend `Exception`, but they are all namespaced files and there is no `use` statement or FQCN, so they will look for an `Exception` class inside the current namespace of the file. This class doesn't exist, so this will also cause an error. I have prepended a slash to indicate the FQCN.

Third, the Client needed to be updated to look for the exceptions in the correct place. Before the namespace change, the exception wouldn't load due to the PSR4 namespace violation. After the namespace change, the Client has to be updated to look at the correct namespace.

I also added in a unit test that tests this one method and the exceptions that it calls. I don't know if you really want this test or not, as the need for it may completely go away with another issue that I will report. But, this is the test that I wrote while working on this code, so I went ahead and included it. I can remove it if you want.