### PR TITLE
Allow passing in custom Guzzle client

### DIFF
--- a/src/Stanley/Geocodio/Client.php
+++ b/src/Stanley/Geocodio/Client.php
@@ -24,11 +24,12 @@ class Client
      * Class constructor
      *
      * @param string $apiKey API Key
+     * @param GuzzleHttp\Client $client Guzzle Client object
      */
-    public function __construct($apiKey = null)
+    public function __construct($apiKey = null, GuzzleClient $client = null)
     {
         $this->apiKey = $apiKey;
-        $this->client = $this->newGuzzleClient();
+        $this->client = $client ?: $this->newGuzzleClient();
     }
 
     /**


### PR DESCRIPTION
This PR updates the Client constructor to allow the consumer to pass in a pre-built Guzzle client, instead of relying on the one built by the Client itself.

This allows the consumer to create a Guzzle client with custom request options that will be used to make the API requests.

It is optional, so if the consumer does not pass one in, it falls back to the default one built by the Client.