### PR TITLE
Update exception handling

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-midnight

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "phpunit/phpunit": "^5"
     },
     "autoload": {
-        "psr-0": {
-            "Stanley\\Geocodio\\": "src/"
+        "psr-4": {
+            "Stanley\\Geocodio\\": "src/Stanley/Geocodio/"
         }
     },
     "minimum-stability": "dev"

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,5 @@
         "psr-4": {
             "Stanley\\Geocodio\\": "src/Stanley/Geocodio/"
         }
-    },
-    "minimum-stability": "dev"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "anthropos9/geocodio-php",
+    "name": "stanley/geocodio-php",
     "description": "Thin wrapper for the Geocodio API",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "stanley/geocodio-php",
+    "name": "anthropos9/geocodio-php",
     "description": "Thin wrapper for the Geocodio API",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,9 @@
         "phpunit/phpunit": "^5"
     },
     "autoload": {
-        "psr-4": {
-            "Stanley\\Geocodio\\": "src/Stanley/Geocodio/"
+        "psr-0": {
+            "Stanley\\Geocodio\\": "src/"
         }
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/src/Stanley/Geocodio/Client.php
+++ b/src/Stanley/Geocodio/Client.php
@@ -212,43 +212,6 @@ class Client
     }
 
     /**
-     * Check response code and throw appropriate exception
-     *
-     * @param  GuzzleHttp\Psr7\Response $response Guzzle Response
-     * @return mixed
-     */
-    protected function checkResponse(Response $response)
-    {
-        $status = $response->getStatusCode();
-        $reason = $response->getReasonPhrase();
-        // die(d($status, $reason));
-
-        switch ($status) {
-            case '403':
-                throw new Stanley\Geocodio\Exception\GeocodioAuthError($reason);
-                break;
-
-            case '422':
-                die('yo');
-                throw new Stanley\Geocodio\Exception\GeocodioDataError($reason);
-                break;
-
-            case '500':
-                throw new Stanley\Geocodio\Exception\GeocodioServerError($reason);
-                break;
-
-            case '200':
-                return $response;
-                break;
-
-            default:
-                throw new Stanley\Geocodio\Exception\GeocodioException("There was a problem with your request - $reason");
-                break;
-        }
-
-    }
-
-    /**
      * Create new Guzzle Client
      *
      * @return GuzzleHttp\Client

--- a/src/Stanley/Geocodio/Client.php
+++ b/src/Stanley/Geocodio/Client.php
@@ -169,7 +169,7 @@ class Client
         die(d($status,$reason));
         switch ($status) {
             case '403':
-                throw new Stanley\Geocodio\GeocodioAuthError($reason)
+                throw new Stanley\Geocodio\GeocodioAuthError($reason);
                 break;
 
             case '422':

--- a/src/Stanley/Geocodio/Client.php
+++ b/src/Stanley/Geocodio/Client.php
@@ -4,10 +4,10 @@ use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Response;
 use Stanley\Geocodio\Data;
-use Stanley\Geocodio\Exception\GeocodioAuthError;
-use Stanley\Geocodio\Exception\GeocodioDataError;
-use Stanley\Geocodio\Exception\GeocodioException;
-use Stanley\Geocodio\Exception\GeocodioServerError;
+use Stanley\Geocodio\Exceptions\GeocodioAuthError;
+use Stanley\Geocodio\Exceptions\GeocodioDataError;
+use Stanley\Geocodio\Exceptions\GeocodioException;
+use Stanley\Geocodio\Exceptions\GeocodioServerError;
 
 class Client
 {

--- a/src/Stanley/Geocodio/Client.php
+++ b/src/Stanley/Geocodio/Client.php
@@ -126,7 +126,7 @@ class Client
             'api_key' => $this->apiKey,
             'fields' => implode(',', $fields)
         ];
-        
+
         $response = $this->client->get($verb, [
             'query' => $params
         ]);
@@ -166,9 +166,10 @@ class Client
     {
         $status = $response->getStatusCode();
         $reason = $response->getReasonPhrase();
+        die(d($status,$reason));
         switch ($status) {
             case '403':
-                throw new Stanley\Geocodio\GeocodioAuthError($reason);
+                throw new Stanley\Geocodio\GeocodioAuthError($reason)
                 break;
 
             case '422':
@@ -197,7 +198,7 @@ class Client
     protected function newGuzzleClient()
     {
         $baseUrl = sprintf(self::BASE_URL, $this->hostname);
-        
+
         return new GuzzleClient([
             'base_uri' => $baseUrl
         ]);

--- a/src/Stanley/Geocodio/Exceptions/GeocodioAuthError.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioAuthError.php
@@ -1,3 +1,5 @@
-<?php namespace Stanley\Geocodio\Exception;
+<?php
+namespace Stanley\Geocodio\Exception;
 
-class GeocodioAuthError extends Exception {}
+class GeocodioAuthError extends Exception
+{}

--- a/src/Stanley/Geocodio/Exceptions/GeocodioAuthError.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioAuthError.php
@@ -1,5 +1,5 @@
 <?php
-namespace Stanley\Geocodio\Exception;
+namespace Stanley\Geocodio\Exceptions;
 
 class GeocodioAuthError extends \Exception
 {

--- a/src/Stanley/Geocodio/Exceptions/GeocodioAuthError.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioAuthError.php
@@ -1,5 +1,14 @@
 <?php
 namespace Stanley\Geocodio\Exception;
 
-class GeocodioAuthError extends Exception
-{}
+class GeocodioAuthError extends \Exception
+{
+    public function __construct($response)
+    {
+        $message  = $response->getBody()->getContents();
+        $code     = $response->getStatusCode();
+        $previous = null;
+        parent::__construct($message, $code, $previous);
+    }
+
+}

--- a/src/Stanley/Geocodio/Exceptions/GeocodioAuthError.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioAuthError.php
@@ -1,3 +1,3 @@
-<?php namespace Stanley\Geocodio;
+<?php namespace Stanley\Geocodio\Exception;
 
 class GeocodioAuthError extends Exception {}

--- a/src/Stanley/Geocodio/Exceptions/GeocodioDataError.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioDataError.php
@@ -1,13 +1,13 @@
 <?php
 namespace Stanley\Geocodio\Exception;
 
-class GeocodioDataError extends Exception
+class GeocodioDataError extends \Exception
 {
 
-    public function __construct($reason)
+    public function __construct($response)
     {
-        $message  = $reason->getMessage();
-        $code     = $reason->getStatusCode();
+        $message  = $response->getBody()->getContents();
+        $code     = $response->getStatusCode();
         $previous = null;
         parent::__construct($message, $code, $previous);
     }

--- a/src/Stanley/Geocodio/Exceptions/GeocodioDataError.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioDataError.php
@@ -1,12 +1,14 @@
-<?php namespace Stanley\Geocodio\Exception;
+<?php
+namespace Stanley\Geocodio\Exception;
 
-class GeocodioDataError extends Exception {
+class GeocodioDataError extends Exception
+{
 
-    function __construct($reason)
+    public function __construct($reason)
     {
-        $message = $reason->getMessage()
-        $code = $reason->getStatusCode();
+        $message  = $reason->getMessage();
+        $code     = $reason->getStatusCode()
         $previous = null;
-        parent::__construct($message,$code,$previous);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Stanley/Geocodio/Exceptions/GeocodioDataError.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioDataError.php
@@ -1,5 +1,5 @@
 <?php
-namespace Stanley\Geocodio\Exception;
+namespace Stanley\Geocodio\Exceptions;
 
 class GeocodioDataError extends \Exception
 {

--- a/src/Stanley/Geocodio/Exceptions/GeocodioDataError.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioDataError.php
@@ -7,7 +7,7 @@ class GeocodioDataError extends Exception
     public function __construct($reason)
     {
         $message  = $reason->getMessage();
-        $code     = $reason->getStatusCode()
+        $code     = $reason->getStatusCode();
         $previous = null;
         parent::__construct($message, $code, $previous);
     }

--- a/src/Stanley/Geocodio/Exceptions/GeocodioDataError.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioDataError.php
@@ -1,3 +1,12 @@
-<?php namespace Stanley\Geocodio;
+<?php namespace Stanley\Geocodio\Exception;
 
-class GeocodioDataError extends Exception {}
+class GeocodioDataError extends Exception {
+
+    function __construct($reason)
+    {
+        $message = $reason->getMessage()
+        $code = $reason->getStatusCode();
+        $previous = null;
+        parent::__construct($message,$code,$previous);
+    }
+}

--- a/src/Stanley/Geocodio/Exceptions/GeocodioException.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioException.php
@@ -1,3 +1,8 @@
 <?php namespace Stanley\Geocodio\Exception;
 
-class GeocodioException extends Exception {}
+class GeocodioException extends Exception {
+    function __construxt($reason)
+    {
+        echo 'blech';
+    }
+}

--- a/src/Stanley/Geocodio/Exceptions/GeocodioException.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioException.php
@@ -1,3 +1,3 @@
-<?php namespace Stanley\Geocodio;
+<?php namespace Stanley\Geocodio\Exception;
 
 class GeocodioException extends Exception {}

--- a/src/Stanley/Geocodio/Exceptions/GeocodioException.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioException.php
@@ -1,8 +1,13 @@
-<?php namespace Stanley\Geocodio\Exception;
+<?php
+namespace Stanley\Geocodio\Exception;
 
-class GeocodioException extends Exception {
-    function __construxt($reason)
+class GeocodioException extends \Exception
+{
+    public function __construct($response)
     {
-        echo 'blech';
+        $message  = $response->getBody()->getContents();
+        $code     = $response->getStatusCode();
+        $previous = null;
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Stanley/Geocodio/Exceptions/GeocodioException.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioException.php
@@ -1,5 +1,5 @@
 <?php
-namespace Stanley\Geocodio\Exception;
+namespace Stanley\Geocodio\Exceptions;
 
 class GeocodioException extends \Exception
 {

--- a/src/Stanley/Geocodio/Exceptions/GeocodioServerError.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioServerError.php
@@ -1,3 +1,3 @@
-<?php namespace Stanley\Geocodio;
+<?php namespace Stanley\Geocodio\Exception;
 
 class GeocodioServerError extends Exception {}

--- a/src/Stanley/Geocodio/Exceptions/GeocodioServerError.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioServerError.php
@@ -1,5 +1,14 @@
 <?php
 namespace Stanley\Geocodio\Exception;
 
-class GeocodioServerError extends Exception
-{}
+class GeocodioServerError extends \Exception
+{
+    public function __construct($response)
+    {
+        $message  = $response->getBody()->getContents();
+        $code     = $response->getStatusCode();
+        $previous = null;
+        parent::__construct($message, $code, $previous);
+    }
+
+}

--- a/src/Stanley/Geocodio/Exceptions/GeocodioServerError.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioServerError.php
@@ -1,3 +1,5 @@
-<?php namespace Stanley\Geocodio\Exception;
+<?php
+namespace Stanley\Geocodio\Exception;
 
-class GeocodioServerError extends Exception {}
+class GeocodioServerError extends Exception
+{}

--- a/src/Stanley/Geocodio/Exceptions/GeocodioServerError.php
+++ b/src/Stanley/Geocodio/Exceptions/GeocodioServerError.php
@@ -1,5 +1,5 @@
 <?php
-namespace Stanley\Geocodio\Exception;
+namespace Stanley\Geocodio\Exceptions;
 
 class GeocodioServerError extends \Exception
 {


### PR DESCRIPTION
Updated the Guzzle requests in the Client object so that they were wrapped in try/catch blocks to catch Guzzle exceptions and throw the appropriate Geocodio exception. Removed the checkResponse method since it was no longer needed. Updated exceptions to use the global Exception object's constructor so that they can be handled within apps using the library. Also updated the namespaces on the exceptions.